### PR TITLE
feat: table.search() support hybrid search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,7 @@
         "sqlmodel",
         "sqls",
         "Streamlit",
+        "tablename",
         "tidbcloud",
         "tiflash"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,8 @@
         "mypy",
         "mysqlconnector",
         "mysqldb",
+        "OLAP",
+        "OLTP",
         "outerjoin",
         "prefilter",
         "primaryjoin",

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
   </a>
 </p>
 
-Python SDK for vector storage and retrieval operations with TiDB.
+A Python SDK for TiDB developers to build AI applications efficiently.
 
+- 🔍 Support various search modes: vector search, fulltext search, hybrid search
 - 🔄 Automatic embedding generation
-- 🔍 Vector similarity search
 - 🎯 Advanced filtering capabilities
-- 📦 Bulk operations support
 - 💱 Transaction support
 - 🔌 [Model Context Protocol (MCP) support](https://github.com/pingcap/pytidb/blob/main/docs/mcp.md)
 
@@ -25,7 +24,7 @@ Documentation: [Jupyter Notebook](https://github.com/pingcap/pytidb/blob/main/do
 ```bash
 pip install pytidb
 
-# If you want to use built-in embedding function.
+# If you want to use built-in embedding function and rerankers.
 pip install "pytidb[models]"
 
 # If you want to convert query result to pandas DataFrame.
@@ -84,13 +83,32 @@ table.bulk_insert(
 )
 ```
 
-### 🔍 Vector Search with Filtering
+### 🔍 Vector Search
 
 ```python
 table.search(
     "A quick fox in the park"
 )  # 👈 The query will be embedding automatically.
 .filter({"user_id": 2})
+.limit(2)
+.to_pandas()
+```
+
+### 🔍 Fulltext Search
+
+```python
+table.search(search_type="fulltext")
+.text("keyword")
+.limit(2)
+.to_pandas()
+```
+
+### 🔍 Hybrid Search
+
+```python
+table.search(search_type="hybrid")
+.text("keyword")
+.vector([1, 2, 3])
 .limit(2)
 .to_pandas()
 ```

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -43,7 +43,7 @@
     }
    ],
    "source": [
-    "%pip install -q \"pytidb==0.0.5.dev6\" \"pytidb[models]==0.0.5.dev6\" pandas"
+    "%pip install -q \"pytidb==0.0.5.dev8\" \"pytidb[models]==0.0.5.dev8\" pandas"
    ]
   },
   {
@@ -55,6 +55,7 @@
     "\n",
     "- Go [tidbcloud.com](https://tidbcloud.com/) or using [tiup playground](https://docs.pingcap.com/tidb/stable/tiup-playground/) to create a free TiDB database cluster.\n",
     "- Go [OpenAI platform](https://platform.openai.com/api-keys) to create your API key.\n",
+    "- Go [jina.ai](https://jina.ai/reranker) to create your Jina API key (For reranker).\n",
     "\n",
     "Configuration can be provided through environment variables, or using `.env`:"
    ]
@@ -86,6 +87,7 @@
     "TIDB_PASSWORD=\n",
     "TIDB_DATABASE=test\n",
     "OPENAI_API_KEY='your_openai_api_key'\n",
+    "JINA_AI_API_KEY='your_jina_api_key'\n",
     "EOF"
    ]
   },
@@ -203,6 +205,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d86d6f78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not table.has_fts_index(\"text\"):\n",
+    "    table.create_fts_index(\"text\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "3eab5d6eaaaaa868",
    "metadata": {},
@@ -214,7 +227,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
+   "id": "d9fcf8fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<coroutine object sleep at 0x108d13b40>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from asyncio import sleep\n",
+    "\n",
+    "table.truncate()\n",
+    "await sleep(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "fc742b2328df41f7",
    "metadata": {
     "ExecuteTime": {
@@ -229,21 +266,31 @@
        "4"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "table.truncate()\n",
     "table.insert(\n",
-    "    Chunk(text=\"The quick brown fox jumps over the lazy dog\", user_id=1),\n",
+    "    Chunk(\n",
+    "        text=\"TiDB is a distributed database that supports OLTP, OLAP, HTAP and AI workloads.\",\n",
+    "        user_id=1,\n",
+    "    ),\n",
     ")\n",
     "table.bulk_insert(\n",
     "    [\n",
-    "        Chunk(text=\"A quick brown dog runs in the park\", user_id=2),\n",
-    "        Chunk(text=\"The lazy fox sleeps under the tree\", user_id=2),\n",
-    "        Chunk(text=\"A dog and a fox play in the park\", user_id=3),\n",
+    "        Chunk(\n",
+    "            text=\"PyTiDB is a Python library for developers to connect to TiDB.\",\n",
+    "            user_id=2,\n",
+    "        ),\n",
+    "        Chunk(\n",
+    "            text=\"LlamaIndex is a framework for building AI applications.\", user_id=2\n",
+    "        ),\n",
+    "        Chunk(\n",
+    "            text=\"OpenAI is a company and platform that provides AI models service and tools.\",\n",
+    "            user_id=3,\n",
+    "        ),\n",
     "    ]\n",
     ")\n",
     "table.rows()"
@@ -258,8 +305,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c4188fdb",
+   "metadata": {},
+   "source": [
+    "You don't need to explicitly include all the keywords in your query — vector search uses **semantic similarity** to help you find the most relevant records."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "bb18652332f9338f",
    "metadata": {
     "ExecuteTime": {
@@ -289,8 +344,6 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>anon_1</th>\n",
-       "      <th>anon_1_1</th>\n",
        "      <th>id</th>\n",
        "      <th>text</th>\n",
        "      <th>text_vec</th>\n",
@@ -302,45 +355,53 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
+       "      <td>3</td>\n",
+       "      <td>LlamaIndex is a framework for building AI appl...</td>\n",
+       "      <td>[-0.009040494, -0.04155857, 0.035607867, -0.03...</td>\n",
        "      <td>2</td>\n",
-       "      <td>A quick brown dog runs in the park</td>\n",
-       "      <td>[-0.04130432, -0.009330943, 0.012396211, -0.03...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0.334641</td>\n",
-       "      <td>0.665359</td>\n",
+       "      <td>0.572058</td>\n",
+       "      <td>0.427942</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
+       "      <td>4</td>\n",
+       "      <td>OpenAI is a company and platform that provides...</td>\n",
+       "      <td>[-0.020635117, -0.021398572, 0.023994321, -0.0...</td>\n",
        "      <td>3</td>\n",
-       "      <td>The lazy fox sleeps under the tree</td>\n",
-       "      <td>[-0.016040476, -0.0027137015, -0.01788162, -0....</td>\n",
+       "      <td>0.603237</td>\n",
+       "      <td>0.396763</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
        "      <td>2</td>\n",
-       "      <td>0.445282</td>\n",
-       "      <td>0.554718</td>\n",
+       "      <td>PyTiDB is a Python library for developers to c...</td>\n",
+       "      <td>[-0.05514111, -0.07355057, -0.006221915, -0.02...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.620352</td>\n",
+       "      <td>0.379648</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  anon_1 anon_1_1  id                                text  \\\n",
-       "0   None     None   2  A quick brown dog runs in the park   \n",
-       "1   None     None   3  The lazy fox sleeps under the tree   \n",
+       "   id                                               text  \\\n",
+       "0   3  LlamaIndex is a framework for building AI appl...   \n",
+       "1   4  OpenAI is a company and platform that provides...   \n",
+       "2   2  PyTiDB is a Python library for developers to c...   \n",
        "\n",
        "                                            text_vec  user_id  _distance  \\\n",
-       "0  [-0.04130432, -0.009330943, 0.012396211, -0.03...        2   0.334641   \n",
-       "1  [-0.016040476, -0.0027137015, -0.01788162, -0....        2   0.445282   \n",
+       "0  [-0.009040494, -0.04155857, 0.035607867, -0.03...        2   0.572058   \n",
+       "1  [-0.020635117, -0.021398572, 0.023994321, -0.0...        3   0.603237   \n",
+       "2  [-0.05514111, -0.07355057, -0.006221915, -0.02...        2   0.620352   \n",
        "\n",
        "     _score  \n",
-       "0  0.665359  \n",
-       "1  0.554718  "
+       "0  0.427942  \n",
+       "1  0.396763  \n",
+       "2  0.379648  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,10 +409,240 @@
    "source": [
     "res = (\n",
     "    table.search(\n",
-    "        \"A quick fox in the park\"\n",
+    "        \"A library for my artificial intelligence software\"\n",
     "    )  # 👈 The query will be embedding automatically.\n",
-    "    .filter({\"user_id\": 2})\n",
-    "    .limit(2)\n",
+    "    .limit(3)\n",
+    "    .to_pandas()\n",
+    ")\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb8a96e7",
+   "metadata": {},
+   "source": [
+    "### Fulltext Search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85424238",
+   "metadata": {},
+   "source": [
+    "Full-text search tokenizes your query into terms and retrieves the records that mention the most keywords. For example, the query with keyword \"library\" will retrieve the records that mention the word \"library\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8cb64706",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>text</th>\n",
+       "      <th>text_vec</th>\n",
+       "      <th>user_id</th>\n",
+       "      <th>_match_score</th>\n",
+       "      <th>_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2</td>\n",
+       "      <td>PyTiDB is a Python library for developers to c...</td>\n",
+       "      <td>[-0.05514111, -0.07355057, -0.006221915, -0.02...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3</td>\n",
+       "      <td>LlamaIndex is a framework for building AI appl...</td>\n",
+       "      <td>[-0.009040494, -0.04155857, 0.035607867, -0.03...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>TiDB is a distributed database that supports O...</td>\n",
+       "      <td>[-0.036524396, -0.026345069, 0.06068818, 0.004...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id                                               text  \\\n",
+       "0   2  PyTiDB is a Python library for developers to c...   \n",
+       "1   3  LlamaIndex is a framework for building AI appl...   \n",
+       "2   1  TiDB is a distributed database that supports O...   \n",
+       "\n",
+       "                                            text_vec  user_id _match_score  \\\n",
+       "0  [-0.05514111, -0.07355057, -0.006221915, -0.02...        2         None   \n",
+       "1  [-0.009040494, -0.04155857, 0.035607867, -0.03...        2         None   \n",
+       "2  [-0.036524396, -0.026345069, 0.06068818, 0.004...        1         None   \n",
+       "\n",
+       "  _score  \n",
+       "0   None  \n",
+       "1   None  \n",
+       "2   None  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res = (\n",
+    "    table.search(search_type=\"fulltext\")\n",
+    "    .text(\"A library for my artificial intelligence software\")\n",
+    "    .limit(3)\n",
+    "    .to_pandas()\n",
+    ")\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b502e48",
+   "metadata": {},
+   "source": [
+    "### Hybrid Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2149820e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>text</th>\n",
+       "      <th>text_vec</th>\n",
+       "      <th>user_id</th>\n",
+       "      <th>_distance</th>\n",
+       "      <th>_score</th>\n",
+       "      <th>_match_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>4</td>\n",
+       "      <td>OpenAI is a company and platform that provides...</td>\n",
+       "      <td>[-0.020635117, -0.021398572, 0.023994321, -0.0...</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.603237</td>\n",
+       "      <td>0.441673</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3</td>\n",
+       "      <td>LlamaIndex is a framework for building AI appl...</td>\n",
+       "      <td>[-0.009040494, -0.04155857, 0.035607867, -0.03...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.572058</td>\n",
+       "      <td>0.437824</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>TiDB is a distributed database that supports O...</td>\n",
+       "      <td>[-0.036524396, -0.026345069, 0.06068818, 0.004...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.229535</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id                                               text  \\\n",
+       "0   4  OpenAI is a company and platform that provides...   \n",
+       "1   3  LlamaIndex is a framework for building AI appl...   \n",
+       "2   1  TiDB is a distributed database that supports O...   \n",
+       "\n",
+       "                                            text_vec  user_id  _distance  \\\n",
+       "0  [-0.020635117, -0.021398572, 0.023994321, -0.0...        3   0.603237   \n",
+       "1  [-0.009040494, -0.04155857, 0.035607867, -0.03...        2   0.572058   \n",
+       "2  [-0.036524396, -0.026345069, 0.06068818, 0.004...        1        NaN   \n",
+       "\n",
+       "     _score _match_score  \n",
+       "0  0.441673         None  \n",
+       "1  0.437824         None  \n",
+       "2  0.229535         None  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pytidb.rerankers import Reranker\n",
+    "\n",
+    "jinaai = Reranker(model_name=\"jina_ai/jina-reranker-v2-base-multilingual\")\n",
+    "\n",
+    "res = (\n",
+    "    table.search(search_type=\"hybrid\")\n",
+    "    .text(\"A library for my artificial intelligence software\")\n",
+    "    .rerank(jinaai, \"text\")  # 👈 Rerank the result set with Jina AI reranker.\n",
+    "    .limit(3)\n",
     "    .to_pandas()\n",
     ")\n",
     "res"
@@ -381,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "5b9277c611a0c7f4",
    "metadata": {
     "ExecuteTime": {
@@ -393,10 +684,12 @@
     {
      "data": {
       "text/plain": [
-       "[(1, 'The quick brown fox jumps over the lazy dog', 1)]"
+       "[(1,\n",
+       "  'TiDB is a distributed database that supports OLTP, OLAP, HTAP and AI workloads.',\n",
+       "  1)]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "2125f53dd5ec80c9",
    "metadata": {
     "ExecuteTime": {
@@ -440,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "id": "54332bb413b12141",
    "metadata": {
     "ExecuteTime": {
@@ -455,7 +748,7 @@
        "User(id=1, name='Alice')"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "b2ec4ea1bd64108c",
    "metadata": {
     "ExecuteTime": {
@@ -479,10 +772,12 @@
     {
      "data": {
       "text/plain": [
-       "[(1, 'The quick brown fox jumps over the lazy dog', 1)]"
+       "[(1,\n",
+       "  'TiDB is a distributed database that supports OLTP, OLAP, HTAP and AI workloads.',\n",
+       "  1)]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -511,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "9709eaa17f375cc4",
    "metadata": {
     "ExecuteTime": {
@@ -523,25 +818,27 @@
     {
      "data": {
       "text/plain": [
-       "('A quick brown dog runs in the park',\n",
-       " array([-0.04130432, -0.00933094,  0.01239621, ..., -0.00589711,\n",
-       "        -0.00739595,  0.01384592], dtype=float32))"
+       "('PyTiDB is a Python library for developers to connect to TiDB.',\n",
+       " array([-0.05514111, -0.07355057, -0.00622192, ...,  0.0079887 ,\n",
+       "         0.01695894,  0.02309906], dtype=float32))"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "old_chunk = table.query({\"text\": \"A quick brown dog runs in the park\"})[0]\n",
+    "old_chunk = table.query(\n",
+    "    {\"text\": \"PyTiDB is a Python library for developers to connect to TiDB.\"}\n",
+    ")[0]\n",
     "chunk_id = old_chunk.id\n",
     "(old_chunk.text, old_chunk.text_vec)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 22,
    "id": "2f60ed130e223985",
    "metadata": {
     "ExecuteTime": {
@@ -561,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 23,
    "id": "99208275",
    "metadata": {
     "ExecuteTime": {
@@ -578,7 +875,7 @@
        "        -0.00738936, -0.01879774], dtype=float32))"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -598,7 +895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 24,
    "id": "d1c01776adcf166b",
    "metadata": {
     "ExecuteTime": {
@@ -613,7 +910,7 @@
        "4"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -624,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 25,
    "id": "ebc3854b4428bda6",
    "metadata": {
     "ExecuteTime": {
@@ -639,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 26,
    "id": "27c539b8f693991",
    "metadata": {
     "ExecuteTime": {
@@ -654,7 +951,7 @@
        "2"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -692,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 27,
    "id": "f4816866cdbbbcfa",
    "metadata": {
     "ExecuteTime": {
@@ -707,7 +1004,7 @@
        "SQLExecuteResult(rowcount=1, success=True, message=None)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -726,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 28,
    "id": "eae7fedce0fc6ffc",
    "metadata": {
     "ExecuteTime": {
@@ -741,7 +1038,7 @@
        "SQLExecuteResult(rowcount=1, success=True, message=None)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -778,7 +1075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 29,
    "id": "564ebe8e3b8fbee",
    "metadata": {
     "ExecuteTime": {
@@ -817,24 +1114,24 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>1</td>\n",
-       "      <td>The quick brown fox jumps over the lazy dog</td>\n",
+       "      <td>TiDB is a distributed database that supports O...</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>4</td>\n",
-       "      <td>A dog and a fox play in the park</td>\n",
+       "      <td>OpenAI is a company and platform that provides...</td>\n",
        "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>5</td>\n",
+       "      <td>30001</td>\n",
        "      <td>inserted from raw sql</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>6</td>\n",
+       "      <td>30002</td>\n",
        "      <td>inserted from dynamic sql</td>\n",
        "      <td>6</td>\n",
        "    </tr>\n",
@@ -843,14 +1140,14 @@
        "</div>"
       ],
       "text/plain": [
-       "   id                                         text  user_id\n",
-       "0   1  The quick brown fox jumps over the lazy dog        1\n",
-       "1   4             A dog and a fox play in the park        3\n",
-       "2   5                        inserted from raw sql        5\n",
-       "3   6                    inserted from dynamic sql        6"
+       "      id                                               text  user_id\n",
+       "0      1  TiDB is a distributed database that supports O...        1\n",
+       "1      4  OpenAI is a company and platform that provides...        3\n",
+       "2  30001                              inserted from raw sql        5\n",
+       "3  30002                          inserted from dynamic sql        6"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -869,7 +1166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 30,
    "id": "97991aed7bd13987",
    "metadata": {
     "ExecuteTime": {
@@ -881,10 +1178,12 @@
     {
      "data": {
       "text/plain": [
-       "[{'id': 4, 'text': 'A dog and a fox play in the park', 'user_id': 3}]"
+       "[{'id': 4,\n",
+       "  'text': 'OpenAI is a company and platform that provides AI models service and tools.',\n",
+       "  'user_id': 3}]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -905,7 +1204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 31,
    "id": "54514f65c6f769e1",
    "metadata": {
     "ExecuteTime": {
@@ -920,7 +1219,7 @@
        "[('chunks',), ('users',)]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -931,7 +1230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 32,
    "id": "b2f3113a0ea9bb1b",
    "metadata": {
     "ExecuteTime": {
@@ -946,7 +1245,7 @@
        "4"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -973,7 +1272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 33,
    "id": "8523e1eb22bee8db",
    "metadata": {
     "ExecuteTime": {
@@ -988,7 +1287,7 @@
        "['chunks', 'users']"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1009,7 +1308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 34,
    "id": "c33600be01633b4e",
    "metadata": {
     "ExecuteTime": {
@@ -1024,7 +1323,7 @@
        "0"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1044,7 +1343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 35,
    "id": "56317418ca9cbbe4",
    "metadata": {
     "ExecuteTime": {
@@ -1059,7 +1358,7 @@
        "SQLExecuteResult(rowcount=0, success=True, message=None)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -43,7 +43,7 @@
     }
    ],
    "source": [
-    "%pip install -q \"pytidb==0.0.5.dev2\" \"pytidb[models]==0.0.5.dev2\" pandas"
+    "%pip install -q \"pytidb==0.0.5.dev6\" \"pytidb[models]==0.0.5.dev6\" pandas"
    ]
   },
   {
@@ -289,52 +289,55 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>anon_1</th>\n",
+       "      <th>anon_1_1</th>\n",
        "      <th>id</th>\n",
        "      <th>text</th>\n",
        "      <th>text_vec</th>\n",
        "      <th>user_id</th>\n",
        "      <th>_distance</th>\n",
-       "      <th>_similarity_score</th>\n",
        "      <th>_score</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "      <td>2</td>\n",
        "      <td>A quick brown dog runs in the park</td>\n",
-       "      <td>[-0.041305702, -0.009355828, 0.01242734, -0.03...</td>\n",
+       "      <td>[-0.04130432, -0.009330943, 0.012396211, -0.03...</td>\n",
        "      <td>2</td>\n",
-       "      <td>0.334585</td>\n",
-       "      <td>0.665415</td>\n",
-       "      <td>0.665415</td>\n",
+       "      <td>0.334641</td>\n",
+       "      <td>0.665359</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "      <td>3</td>\n",
        "      <td>The lazy fox sleeps under the tree</td>\n",
-       "      <td>[-0.016045703, -0.002672629, -0.017925644, -0....</td>\n",
+       "      <td>[-0.016040476, -0.0027137015, -0.01788162, -0....</td>\n",
        "      <td>2</td>\n",
-       "      <td>0.445202</td>\n",
-       "      <td>0.554798</td>\n",
-       "      <td>0.554798</td>\n",
+       "      <td>0.445282</td>\n",
+       "      <td>0.554718</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   id                                text  \\\n",
-       "0   2  A quick brown dog runs in the park   \n",
-       "1   3  The lazy fox sleeps under the tree   \n",
+       "  anon_1 anon_1_1  id                                text  \\\n",
+       "0   None     None   2  A quick brown dog runs in the park   \n",
+       "1   None     None   3  The lazy fox sleeps under the tree   \n",
        "\n",
        "                                            text_vec  user_id  _distance  \\\n",
-       "0  [-0.041305702, -0.009355828, 0.01242734, -0.03...        2   0.334585   \n",
-       "1  [-0.016045703, -0.002672629, -0.017925644, -0....        2   0.445202   \n",
+       "0  [-0.04130432, -0.009330943, 0.012396211, -0.03...        2   0.334641   \n",
+       "1  [-0.016040476, -0.0027137015, -0.01788162, -0....        2   0.445282   \n",
        "\n",
-       "   _similarity_score    _score  \n",
-       "0           0.665415  0.665415  \n",
-       "1           0.554798  0.554798  "
+       "     _score  \n",
+       "0  0.665359  \n",
+       "1  0.554718  "
       ]
      },
      "execution_count": 7,
@@ -521,8 +524,8 @@
      "data": {
       "text/plain": [
        "('A quick brown dog runs in the park',\n",
-       " array([-0.0413057 , -0.00935583,  0.01242734, ..., -0.00587273,\n",
-       "        -0.00737163,  0.01383409], dtype=float32))"
+       " array([-0.04130432, -0.00933094,  0.01239621, ..., -0.00589711,\n",
+       "        -0.00739595,  0.01384592], dtype=float32))"
       ]
      },
      "execution_count": 12,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytidb"
-version = "0.0.5.dev5"
+version = "0.0.5.dev6"
 description = "A Python library for TiDB."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     { name = "sykp241095", email = "sykp241095@gmail.com" },
 ]
 dependencies = [
-    "sqlmodel==0.0.24",
+    "sqlmodel>=0.0.14",
     "tidb-vector>=0.0.14",
     "pymysql>=1.1.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytidb"
-version = "0.0.5.dev6"
+version = "0.0.5.dev8"
 description = "A Python library for TiDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pytidb/search.py
+++ b/pytidb/search.py
@@ -402,7 +402,7 @@ class SearchQuery:
             else:
                 # Sort the rows by score.
                 rows = sorted(
-                    rows, key=lambda row: row._mapping["_score"], reverse=True
+                    rows, key=lambda row: row._mapping[SCORE_LABEL] or 0, reverse=True
                 )
 
             return keys, rows[: self._limit]

--- a/pytidb/search.py
+++ b/pytidb/search.py
@@ -65,6 +65,7 @@ class SearchResult(BaseModel, Generic[T]):
             f"'{self.__class__.__name__}' object has no attribute '{item}'"
         )
 
+    @property
     def similarity_score(self) -> float:
         if self.distance is not None:
             return 1 - self.distance
@@ -383,13 +384,13 @@ class SearchQuery:
             fts_result = db_session.execute(fts_query)
             fts_rows = fts_result.fetchall()
 
-            # Merge the keys and rows from vector search and fulltext search.
+            # Merge the rows from vector search and fulltext search.
             def get_row_id(row: Row) -> Optional[int]:
                 return get_row_id_from_row(row, self._sa_table)
 
             keys, rows = merge_result_rows(vs_rows, fts_rows, get_row_id)
 
-            # Apply reranker to improve the quality of fulltext search results. (Optional)
+            # Apply reranker to rerank the merged result set. (Optional)
             if self._reranker is not None:
                 rows = self._rerank_result_set(rows)
             else:

--- a/pytidb/search.py
+++ b/pytidb/search.py
@@ -249,7 +249,6 @@ class SearchQuery:
         stmt = select(
             subquery.c[ROW_ID_LABEL] if self._sa_table.primary_key is None else None,
             subquery.c,
-            literal(None).label(MATCH_SCORE_LABEL),
             (1 - subquery.c[DISTANCE_LABEL]).label(SCORE_LABEL),
         )
 
@@ -304,7 +303,6 @@ class SearchQuery:
         stmt = select(
             text("_tidb_rowid") if self._sa_table.primary_key is None else None,
             columns,
-            literal(None).label(DISTANCE_LABEL),
             literal(None).label(MATCH_SCORE_LABEL),
             literal(None).label(SCORE_LABEL),
         ).filter(fts_match_word(self._query_text, text_column))
@@ -475,9 +473,7 @@ class SearchQuery:
         results = []
         for row in rows:
             values: Dict[str, Any] = dict(row._mapping)
-            distance_score = (
-                values.pop(DISTANCE_LABEL) if DISTANCE_LABEL in values else None
-            )
+            distance = values.pop(DISTANCE_LABEL) if DISTANCE_LABEL in values else None
             match_score = (
                 values.pop(MATCH_SCORE_LABEL) if MATCH_SCORE_LABEL in values else None
             )
@@ -489,7 +485,7 @@ class SearchQuery:
             else:
                 results.append(
                     SearchResult(
-                        distance=distance_score,
+                        distance=distance,
                         match_score=match_score,
                         score=score,
                         hit=hit,

--- a/tests/test_search_hybrid.py
+++ b/tests/test_search_hybrid.py
@@ -53,7 +53,6 @@ def test_hybrid_search(hybrid_table: Table):
     # to_pydantic()
     results = (
         hybrid_table.search("HTAP database", search_type="hybrid")
-        .debug()
         .text_column("text")
         .limit(2)
         .to_pydantic()

--- a/tests/test_search_hybrid.py
+++ b/tests/test_search_hybrid.py
@@ -1,0 +1,105 @@
+import os
+import pytest
+
+from pytidb import TiDBClient, Table
+from pytidb.embeddings import EmbeddingFunction
+from pytidb.rerankers import Reranker
+from pytidb.rerankers.base import BaseReranker
+from pytidb.schema import TableModel, Field
+
+
+@pytest.fixture(scope="module")
+def hybrid_table(db: TiDBClient):
+    text_embed_small = EmbeddingFunction("openai/text-embedding-3-small")
+
+    class Chunk(TableModel, table=True):
+        __tablename__ = "chunks_for_hybrid"
+        id: int = Field(None, primary_key=True)
+        text: str = Field(None)
+        text_vec: list[float] = text_embed_small.VectorField(source_field="text")
+        user_id: int = Field(None)
+
+    tbl = db.create_table(schema=Chunk)
+
+    # Prepare test data.
+    tbl.delete()
+    tbl.bulk_insert(
+        [
+            Chunk(
+                id=1,
+                text="TiDB is a distributed database that supports OLTP, OLAP, HTAP and AI workloads.",
+                user_id=1,
+            ),
+            Chunk(
+                id=2,
+                text="LlamaIndex is a framework for building AI applications.",
+                user_id=2,
+            ),
+            Chunk(
+                id=3,
+                text="OpenAI is a company that provides a platform for building AI models.",
+                user_id=3,
+            ),
+        ]
+    )
+
+    if not tbl.has_fts_index("text"):
+        tbl.create_fts_index("text")
+
+    return tbl
+
+
+def test_hybrid_search(hybrid_table: Table):
+    # to_pydantic()
+    results = (
+        hybrid_table.search("HTAP database", search_type="hybrid")
+        .debug()
+        .text_column("text")
+        .limit(2)
+        .to_pydantic()
+    )
+    assert len(results) == 2
+    assert "TiDB" in results[0].text
+    assert results[0].user_id == 1
+    assert results[0].score > 0
+
+    # to_pandas()
+    results = (
+        hybrid_table.search(search_type="hybrid")
+        .text("Framework helps develop intelligent applications")
+        .limit(2)
+        .to_pandas()
+    )
+    assert results.size > 0
+    assert "LlamaIndex" in results.iloc[0]["text"]
+    assert results.iloc[0]["user_id"] == 2
+
+    # to_list()
+    results = (
+        hybrid_table.search(search_type="hybrid").text("OpenAI").limit(2).to_list()
+    )
+    assert len(results) > 0
+    assert "OpenAI" in results[0]["text"]
+    assert results[0]["user_id"] == 3
+
+
+@pytest.fixture(scope="module")
+def reranker():
+    return Reranker(
+        model_name="jina_ai/jina-reranker-v2-base-multilingual",
+        api_key=os.getenv("JINA_API_KEY"),
+    )
+
+
+def test_rerank(hybrid_table: Table, reranker: BaseReranker):
+    reranked_results = (
+        hybrid_table.search(search_type="hybrid")
+        .text("An AI library to develop AI applications")
+        .rerank(reranker, "text")
+        .limit(3)
+        .to_list()
+    )
+
+    assert len(reranked_results) > 0
+    assert "LlamaIndex" in reranked_results[0]["text"]
+    assert reranked_results[0]["_score"] > 0

--- a/tests/test_search_vector.py
+++ b/tests/test_search_vector.py
@@ -8,7 +8,7 @@ from pytidb.rerankers import Reranker
 from pytidb.rerankers.base import BaseReranker
 from pytidb.schema import DistanceMetric, TableModel, Field, Column
 from pytidb.datatype import Vector
-from pytidb.search import SIMILARITY_SCORE_LABEL
+from pytidb.search import SCORE_LABEL
 
 
 # Vector Search
@@ -62,7 +62,7 @@ def test_vector_search(vector_table: Table):
     results = vector_table.search([1, 2, 3]).limit(2).to_list()
     assert len(results) > 0
     assert results[0]["text"] == "bar"
-    assert results[0][SIMILARITY_SCORE_LABEL] == 1
+    assert results[0][SCORE_LABEL] == 1
     assert results[0]["user_id"] == 2
     assert results[0]["_distance"] == 0
     assert results[0]["_score"] == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
-from pytidb.utils import build_tidb_dsn
+from typing import Optional
+from sqlalchemy import Row
+from sqlalchemy.engine.result import result_tuple
+from pytidb.utils import build_tidb_dsn, merge_result_rows
 
 
 def test_build_tidb_dsn():
@@ -28,3 +31,116 @@ def test_build_tidb_dsn():
     assert dsn.path == "/test"
     assert dsn.query is None
     assert str(dsn) == "mysql+pymysql://root:password@localhost:4000/test"
+
+
+def test_merge_result_rows():
+    # Define test data structure
+    fields_a = ["user_id", "name", "score"]
+    fields_b = ["user_id", "city", "score"]
+    row_factory_a = result_tuple(fields_a)
+    row_factory_b = result_tuple(fields_b)
+
+    # Prepare test data for set A
+    rows_a = [
+        row_factory_a([1, "Alice", 85]),  # score not None, should keep this
+        row_factory_a([2, "Bob", None]),  # score None, should take from secondary
+        row_factory_a([3, "Charlie", 95]),  # score not None, should keep this
+    ]
+
+    # Prepare test data for set B
+    rows_b = [
+        row_factory_b([2, "London", 88]),  # should override primary's None
+        row_factory_b([3, "Paris", 92]),  # should not override primary's value
+        row_factory_b([4, "Berlin", 78]),  # only in secondary
+    ]
+
+    def get_row_id(row: Row) -> Optional[int]:
+        return row.user_id
+
+    merged_fields, merged_rows = merge_result_rows(rows_a, rows_b, get_row_id)
+    merged_by_id = {row.user_id: row for row in merged_rows}
+
+    # Verify merged fields
+    assert merged_fields == ["user_id", "name", "score", "city"]
+
+    # Verify row present only in primary set
+    alice = merged_by_id[1]
+    assert alice.name == "Alice"
+    assert alice.score == 85
+    assert alice.city is None
+
+    # Verify row with None score in primary set
+    bob = merged_by_id[2]
+    assert bob.name == "Bob"
+    assert bob.city == "London"
+    assert bob.score == 88  # Takes score from secondary
+
+    # Verify row with non-None score in both sets
+    charlie = merged_by_id[3]
+    assert charlie.name == "Charlie"
+    assert charlie.city == "Paris"
+    assert charlie.score == 95  # Keeps score from primary
+
+    # Verify row present only in secondary set
+    david = merged_by_id[4]
+    assert david.name is None
+    assert david.city == "Berlin"
+    assert david.score == 78
+
+    # Verify edge cases
+    empty_fields, empty_rows = merge_result_rows([], rows_b, get_row_id)
+    assert empty_rows == rows_b
+    assert empty_fields == ["user_id", "city", "score"]
+
+    empty_fields, empty_rows = merge_result_rows(rows_a, [], get_row_id)
+    assert empty_rows == rows_a
+    assert empty_fields == ["user_id", "name", "score"]
+
+
+def test_merge_result_rows_with_fusion():
+    fields_a = ["id", "score", "distance"]
+    fields_b = ["id", "score", "distance"]
+    row_factory_a = result_tuple(fields_a)
+    row_factory_b = result_tuple(fields_b)
+
+    rows_a = [
+        row_factory_a([1, 85, 2]),
+        row_factory_a([2, None, 200]),  # score is None in rows_a
+        row_factory_a([3, 95, 10]),
+    ]
+
+    rows_b = [
+        row_factory_b([1, 90, 50]),
+        row_factory_b([2, 88, 10]),
+        row_factory_b([3, 92, None]),  # distance is None in rows_b
+    ]
+
+    def sum_fusion(
+        value_a: Optional[float], value_b: Optional[float], row_a: Row, row_b: Row
+    ) -> Optional[float]:
+        return (value_a or 0) + (value_b or 0)
+
+    def multiply_fusion(
+        value_a: Optional[float], value_b: Optional[float], row_a: Row, row_b: Row
+    ) -> Optional[float]:
+        return (value_a or 1) * (value_b or 1)
+
+    merge_strategies = {"score": sum_fusion, "distance": multiply_fusion}
+
+    def get_row_id(row: Row) -> Optional[int]:
+        return row.id
+
+    _, merged_rows = merge_result_rows(rows_a, rows_b, get_row_id, merge_strategies)
+    rows_by_id = {row.id: row for row in merged_rows}
+
+    # Case 1: Both values present - sum score and multiply distance
+    assert rows_by_id[1].score == 175  # 85 + 90
+    assert rows_by_id[1].distance == 100  # 2 * 50
+
+    # Case 2: Score None in rows_a - take rows_b score
+    assert rows_by_id[2].score == 88  # None + 88 = 88
+    assert rows_by_id[2].distance == 2000  # 200 * 10
+
+    # Case 3: Distance None in rows_b
+    assert rows_by_id[3].score == 187  # 95 + 92
+    assert rows_by_id[3].distance == 10  # 10 * 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,10 +137,10 @@ def test_merge_result_rows_with_fusion():
     assert rows_by_id[1].score == 175  # 85 + 90
     assert rows_by_id[1].distance == 100  # 2 * 50
 
-    # Case 2: Score None in rows_a - take rows_b score
-    assert rows_by_id[2].score == 88  # None + 88 = 88
+    # Case 2: Score None in rows_a
+    assert rows_by_id[2].score == 88  # 0 (None) + 88 = 88
     assert rows_by_id[2].distance == 2000  # 200 * 10
 
     # Case 3: Distance None in rows_b
     assert rows_by_id[3].score == 187  # 95 + 92
-    assert rows_by_id[3].distance == 10  # 10 * 1
+    assert rows_by_id[3].distance == 10  # 10 * 1 (None)

--- a/uv.lock
+++ b/uv.lock
@@ -2087,7 +2087,7 @@ wheels = [
 
 [[package]]
 name = "pytidb"
-version = "0.0.5.dev5"
+version = "0.0.5.dev6"
 source = { editable = "." }
 dependencies = [
     { name = "pymysql" },
@@ -2129,7 +2129,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.6.0" },
     { name = "pandas", marker = "extra == 'pandas'" },
     { name = "pymysql", specifier = ">=1.1.1" },
-    { name = "sqlmodel", specifier = "==0.0.24" },
+    { name = "sqlmodel", specifier = ">=0.0.14" },
     { name = "tidb-vector", specifier = ">=0.0.14" },
 ]
 provides-extras = ["mcp", "pandas", "models"]


### PR DESCRIPTION
close #54

- **Hybrid Search Support**: Added a hybrid search capability combining vector and full-text search for enhanced flexibility.

  **Usage:**
  
  ```python
  results = (
      table.search(search_type="hybrid")
      .text("AI library for developers")  # Full-text search keywords
      .vector([0.1, 0.2, 0.3])  # Query vector
      .limit(5)  # Limit results to 5
      .to_list()
  )
  ```

- **Search Result Improvements**: Updated `SearchResult` to include new fields like `match_score` and `distance` for better result insights.

