### PR TITLE
fix: avoid error when bulk insert without auto embedding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytidb"
-version = "0.0.5"
+version = "0.0.5.post1"
 description = "A Python library for TiDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pytidb/table.py
+++ b/pytidb/table.py
@@ -178,15 +178,25 @@ class Table(Generic[T]):
         for field_name, config in self._vector_field_configs.items():
             items_need_embedding = []
             sources_to_embedding = []
+
+            # Skip if no embedding function is provided.
+            if "embed_fn" not in config or config["embed_fn"] is None:
+                continue
+
             for item in data:
+                # Skip if vector embeddings is provided.
                 if getattr(item, field_name) is not None:
                     continue
+
+                # Skip if no source field is provided.
                 if not hasattr(item, config["source_field_name"]):
                     continue
+
                 items_need_embedding.append(item)
                 embedding_source = getattr(item, config["source_field_name"])
                 sources_to_embedding.append(embedding_source)
 
+            # Batch embedding.
             vector_embeddings = config["embed_fn"].get_source_embeddings(
                 sources_to_embedding
             )

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -28,8 +28,12 @@ def test_table_crud(db):
 
     # CREATE
     tbl.insert(Chunk(id=1, text="foo", text_vec=[1, 2, 3]))
-    tbl.insert(Chunk(id=2, text="bar", text_vec=[4, 5, 6]))
-    tbl.insert(Chunk(id=3, text="biz", text_vec=[7, 8, 9]))
+    tbl.bulk_insert(
+        [
+            Chunk(id=2, text="bar", text_vec=[4, 5, 6]),
+            Chunk(id=3, text="biz", text_vec=[7, 8, 9]),
+        ]
+    )
 
     # RETRIEVE
     c = tbl.get(1)


### PR DESCRIPTION
Fix error:

```
>           vector_embeddings = config["embed_fn"].get_source_embeddings(
                sources_to_embedding
            )
E           AttributeError: 'NoneType' object has no attribute 'get_source_embeddings'
```