### PR TITLE
fix: avoid error when using implicit $eq operator for json column

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytidb"
-version = "0.0.5.post1"
+version = "0.0.5.post2"
 description = "A Python library for TiDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -123,7 +123,10 @@ filter_test_data = [
     pytest.param(
         {"meta.f": {"$gte": 0.5}}, ["bar", "biz"], id="json column: $gt operator"
     ),
-    pytest.param({"meta.s": {"$eq": "apple"}}, ["foo"], id="json column: $eq operator"),
+    pytest.param(
+        {"meta.s": {"$eq": "apple"}}, ["foo"], id="json column: explicit $eq operator"
+    ),
+    pytest.param({"meta.s": "apple"}, ["foo"], id="json column: implicit $eq operator"),
 ]
 
 


### PR DESCRIPTION
Fix error:

```
    def build_column_filter(
        column: Any, conditions: Dict[str, Any]
    ) -> Optional[BinaryExpression]:
        column_filters = []
>       for operator, val in conditions.items():
E       AttributeError: 'str' object has no attribute 'items'

pytidb/utils.py:194: AttributeError
```