### PR TITLE
fix: add click for mcp and support uvx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,14 @@ dependencies = [
     "sqlmodel>=0.0.14",
     "tidb-vector>=0.0.14",
     "pymysql>=1.1.1",
+    "mcp[cli]>=1.6.0",
+    "mcp",
 ]
 
 [project.scripts]
 tidb-mcp-server = "pytidb.ext.mcp:main"
 
 [project.optional-dependencies]
-mcp = [
-    "mcp[cli]>=1.6.0",
-    "mcp",
-]
 pandas = [
     "pandas"
 ]
@@ -44,6 +42,7 @@ dev = [
     "mypy>=1.15.0",
     "mcp[cli]>=1.6.0",
     "mcp",
+    "click>=8.2.1",
 ]
 
 # Test

--- a/uv.lock
+++ b/uv.lock
@@ -414,6 +414,7 @@ source = { virtual = "docs" }
 dependencies = [
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-redirects" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
 
@@ -421,6 +422,7 @@ dependencies = [
 requires-dist = [
     { name = "mkdocs-jupyter", specifier = ">=0.25.1" },
     { name = "mkdocs-material", specifier = ">=9.6.12" },
+    { name = "mkdocs-redirects", specifier = ">=1.2.2" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
 ]
 
@@ -1282,6 +1284,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-redirects"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a8/6d44a6cf07e969c7420cb36ab287b0669da636a2044de38a7d2208d5a758/mkdocs_redirects-1.2.2.tar.gz", hash = "sha256:3094981b42ffab29313c2c1b8ac3969861109f58b2dd58c45fc81cd44bfa0095", size = 7162 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ec/38443b1f2a3821bbcb24e46cd8ba979154417794d54baf949fefde1c2146/mkdocs_redirects-1.2.2-py3-none-any.whl", hash = "sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5", size = 6142 },
+]
+
+[[package]]
 name = "mkdocstrings"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1979,6 +1993,7 @@ dependencies = [
 
 [package.optional-dependencies]
 mcp = [
+    { name = "click" },
     { name = "mcp", extra = ["cli"] },
 ]
 models = [
@@ -2006,6 +2021,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", marker = "extra == 'mcp'" },
     { name = "litellm", marker = "extra == 'models'", specifier = ">=1.59.8,<2.0.0" },
     { name = "mcp", marker = "extra == 'mcp'" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.6.0" },


### PR DESCRIPTION
this patch support uvx close #97 

detail

- most server use uvx to run

you can try this patch:

1. export TiDB env
2. uvx --from git+https://github.com/yihong0618/pytidb.git  tidb-mcp-server