### PR TITLE
fix: Add litellm to memory example

### DIFF
--- a/examples/memory/reqs.txt
+++ b/examples/memory/reqs.txt
@@ -1,5 +1,4 @@
 pytidb
-pymysql
-python-dotenv
+pytidb[models]
 openai
-litellm
+python-dotenv

--- a/examples/memory/reqs.txt
+++ b/examples/memory/reqs.txt
@@ -2,3 +2,4 @@ pytidb
 pymysql
 python-dotenv
 openai
+litellm


### PR DESCRIPTION
This commit adds litellm to memory example to address `ModuleNotFoundError: No module named 'litellm'` error.


### Steps to reproduce
Follow the steps described at https://github.com/pingcap/pytidb/tree/main/examples/memory#how-to-run

### Expected behavior
`python main.py` should run without errors.

### Actual behavior without this fix
It raises the "ModuleNotFoundError: No module named 'litellm'"

```python
(.venv) ~/src/github.com/pingcap/pytidb/examples/memory % python main.py

Traceback (most recent call last):
  File "/Users/yahonda@pingcap.com/src/github.com/pingcap/pytidb/examples/memory/main.py", line 22, in <module>
    embedding_fn = EmbeddingFunction(
        model_name="text-embedding-3-small", api_key=os.getenv("OPENAI_API_KEY")
    )
  File "/Users/yahonda@pingcap.com/src/github.com/pingcap/pytidb/examples/memory/.venv/lib/python3.13/site-packages/pytidb/embeddings/litellm.py", line 69, in __init__
    self.dimensions = len(self.get_query_embedding("test"))
                          ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/yahonda@pingcap.com/src/github.com/pingcap/pytidb/examples/memory/.venv/lib/python3.13/site-packages/pytidb/embeddings/litellm.py", line 72, in get_query_embedding
    embeddings = get_embeddings(
        api_key=self.api_key,
    ...<4 lines>...
        input=[query],
    )
  File "/Users/yahonda@pingcap.com/src/github.com/pingcap/pytidb/examples/memory/.venv/lib/python3.13/site-packages/pytidb/embeddings/litellm.py", line 29, in get_embeddings
    from litellm import embedding
ModuleNotFoundError: No module named 'litellm'
(.venv) ~/src/github.com/pingcap/pytidb/examples/memory %
```
### Actual behavior with this fix

It works as expected that Chat with AI shows the prompt below.
```python
(.venv) ~/src/github.com/pingcap/pytidb/examples/memory % python main.py

Chat with AI (type 'exit' to quit)
You:
```
