### PR TITLE
chore: refine TiDBClient function names

### DIFF
--- a/examples/text2sql/main.py
+++ b/examples/text2sql/main.py
@@ -66,7 +66,7 @@ for item in ["generated", "past"]:
 
 table_definitions = []
 current_database = db._db_engine.url.database
-for table_name in db.table_names():
+for table_name in db.list_tables():
     table_definitions.append(db.query(f"SHOW CREATE TABLE `{table_name}`").to_rows()[0])
 
 

--- a/pytidb/__init__.py
+++ b/pytidb/__init__.py
@@ -1,9 +1,11 @@
 import os
 
-from .client import TiDBClient
-from .table import Table
 from sqlmodel import Session
 from sqlalchemy import create_engine
+
+from .client import TiDBClient
+from .table import Table
+from .utils import build_tidb_dsn
 
 if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
@@ -12,4 +14,4 @@ if "LITELLM_LOG" not in os.environ:
     os.environ["LITELLM_LOG"] = "WARNING"
 
 
-__all__ = ["TiDBClient", "Table", "Session", "create_engine"]
+__all__ = ["TiDBClient", "Table", "build_tidb_dsn", "Session", "create_engine"]

--- a/pytidb/client.py
+++ b/pytidb/client.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import List, Literal, Optional, Type, Generator, Union
+from typing import List, Literal, Optional, Type, Generator
 
 from pydantic import PrivateAttr
 import sqlalchemy

--- a/pytidb/ext/mcp/server.py
+++ b/pytidb/ext/mcp/server.py
@@ -40,7 +40,7 @@ class TiDBConnector:
         database: Optional[str] = None,
     ):
         self.tidb_client = TiDBClient.connect(
-            database_url=database_url,
+            dsn=database_url,
             host=host,
             port=port,
             username=username,
@@ -79,7 +79,7 @@ class TiDBConnector:
         )
 
     def show_tables(self) -> list[str]:
-        return self.tidb_client.table_names()
+        return self.tidb_client.list_tables()
 
     def query(self, sql_stmt: str) -> list[dict]:
         return self.tidb_client.query(sql_stmt).to_list()
@@ -174,13 +174,13 @@ async def app_lifespan(app: FastMCP) -> AsyncIterator[AppContext]:
 # MCP Server
 mcp = FastMCP(
     "tidb",
-    instructions="""You are a tidb database expert, you can help me query, create, and execute sql 
+    instructions="""You are a tidb database expert, you can help me query, create, and execute sql
 statements on the tidb database.
 
 Notice:
 - use TiDB instead of MySQL syntax for sql statements
 - use `db_query("SHOW DATABASES()")` to get the current database.
-- use switch_database tool only if there's explicit instruction, you can reference different databases 
+- use switch_database tool only if there's explicit instruction, you can reference different databases
 via the `<db_name>.<table_name>` syntax.
 - TiDB using VECTOR to store the vector data
 
@@ -202,7 +202,7 @@ via the `<db_name>.<table_name>` syntax.
     ORDER BY similarity DESC
     LIMIT 3;
     ```
-    
+
     """,
     lifespan=app_lifespan,
 )
@@ -224,9 +224,9 @@ def show_databases(ctx: Context) -> list[dict]:
 @mcp.tool(
     description="""
     Switch to a specific database.
-    
+
     Note:
-    - The user has already specified the database in the configuration, so you don't need to switch 
+    - The user has already specified the database in the configuration, so you don't need to switch
     database before you execute the sql statements.
     """
 )

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -14,7 +14,7 @@ def test_databases(client):
     client.create_database(db_name, skip_exists=True)
 
     # list database names.
-    db_names = client.database_names()
+    db_names = client.list_databases()
     assert db_name in db_names
     assert client.has_database(db_name)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,12 +8,6 @@ def test_build_tidb_dsn():
         username="xxxxxxxx.root",
         password="$password$",
     )
-    assert dsn.host == "gateway01.us-west-2.prod.aws.tidbcloud.com"
-    assert dsn.port == 4000
-    assert dsn.username == "xxxxxxxx.root"
-    assert dsn.password == "%24password%24"
-    assert dsn.path == "/test"
-    assert dsn.query == "ssl_verify_cert=true&ssl_verify_identity=true"
     assert (
         str(dsn)
         == "mysql+pymysql://xxxxxxxx.root:%24password%24@gateway01.us-west-2.prod.aws.tidbcloud.com:4000/test?ssl_verify_cert=true&ssl_verify_identity=true"
@@ -21,10 +15,4 @@ def test_build_tidb_dsn():
 
     # For TiDB Cluster on local.
     dsn = build_tidb_dsn(host="localhost", username="root", password="password")
-    assert dsn.host == "localhost"
-    assert dsn.port == 4000
-    assert dsn.username == "root"
-    assert dsn.password == "password"
-    assert dsn.path == "/test"
-    assert dsn.query is None
     assert str(dsn) == "mysql+pymysql://root:password@localhost:4000/test"


### PR DESCRIPTION
Changeset 1. Better aligned with `verb_noun` naming convention of other functions

- `TiDBClient.table_names` -> `TiDBClient.list_tables`.
- `TiDBClient.database_names` -> `TiDBClient.list_databases`.
- Expose function `build_tidb_dsn` so that user can build the DSN string programmatically.

BTW it is pretty wired that build_tidb_dsn itself can "inject advanced parameters like ssl_verify_cert" while users cannot, which should be fixed in future.