### PR TITLE
feat: add tidb dialect

### DIFF
--- a/pytidb/__init__.py
+++ b/pytidb/__init__.py
@@ -2,10 +2,17 @@ import os
 
 from sqlmodel import Session
 from sqlalchemy import create_engine
+from sqlalchemy.dialects import registry
 
 from .client import TiDBClient
 from .table import Table
 from .utils import build_tidb_connection_url
+from .orm.dialects.tidb import TiDBDialect
+from .orm.tiflash_repilica import TiFlashReplica
+
+# Register the TiDB dialect with SQLAlchemy
+registry.register("tidb", "pytidb.orm.dialects.tidb", "TiDBDialect")
+registry.register("tidb.pymysql", "pytidb.orm.dialects.tidb", "TiDBDialect")
 
 if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
@@ -15,8 +22,10 @@ if "LITELLM_LOG" not in os.environ:
 
 
 __all__ = [
+    "TiDBDialect",
     "TiDBClient",
     "Table",
+    "TiFlashReplica",
     "build_tidb_connection_url",
     "Session",
     "create_engine",

--- a/pytidb/client.py
+++ b/pytidb/client.py
@@ -40,6 +40,9 @@ class TiDBClient:
         self._db_engine = db_engine
         self._identifier_preparer = self._db_engine.dialect.identifier_preparer
         self._reconnect_params = reconnect_params
+        self._is_serverless = bool(
+            TIDB_SERVERLESS_HOST_PATTERN.match(self._db_engine.url.host)
+        )
 
     # TODO: Better typing for kwargs, including what's supported by pymysql and SQLAlchemy.
     @classmethod
@@ -99,6 +102,15 @@ class TiDBClient:
     @property
     def db_engine(self) -> Engine:
         return self._db_engine
+
+    @property
+    def is_serverless(self) -> bool:
+        """Check if the client is connected to TiDB Serverless.
+
+        Returns:
+            True if connected to TiDB Serverless, False otherwise.
+        """
+        return self._is_serverless
 
     # Database Management API
 

--- a/pytidb/orm/dialects/__init__.py
+++ b/pytidb/orm/dialects/__init__.py
@@ -1,0 +1,8 @@
+"""
+TiDB Dialects Package
+SQLAlchemy dialects for TiDB database.
+"""
+
+from .tidb import TiDBDialect
+
+__all__ = ["TiDBDialect"]

--- a/pytidb/orm/dialects/tidb.py
+++ b/pytidb/orm/dialects/tidb.py
@@ -1,0 +1,258 @@
+"""
+TiDB Dialect
+"""
+
+import sqlalchemy
+from sqlalchemy.dialects.mysql.base import MySQLCompiler, MySQLDDLCompiler
+from sqlalchemy.dialects.mysql.pymysql import MySQLDialect_pymysql
+from sqlalchemy.sql.ddl import CreateIndex
+from sqlalchemy.sql import sqltypes
+from sqlalchemy.sql import elements
+from sqlalchemy.sql import functions
+from sqlalchemy.sql import operators
+
+
+class CreateIndexInline(CreateIndex):
+    """DDL element for inline index creation within CREATE TABLE."""
+
+    __visit_name__ = "create_index_inline"
+
+    def __init__(self, element, if_not_exists=False):
+        super().__init__(element, if_not_exists=if_not_exists)
+
+
+class TiDBSQLCompiler(MySQLCompiler):
+    """Custom SQL compiler for TiDB with enhanced CREATE TABLE support."""
+
+    pass
+
+
+class TiDBDDLCompiler(MySQLDDLCompiler):
+    """Custom DDL compiler for TiDB with enhanced CREATE TABLE support."""
+
+    def visit_create_table(self, create, **kw):
+        table = create.element
+        preparer = self.preparer
+
+        text = "\nCREATE "
+        if table._prefixes:
+            text += " ".join(table._prefixes) + " "
+
+        text += "TABLE "
+        if create.if_not_exists:
+            text += "IF NOT EXISTS "
+
+        text += preparer.format_table(table) + " "
+
+        create_table_suffix = self.create_table_suffix(table)
+        if create_table_suffix:
+            text += create_table_suffix + " "
+
+        text += "("
+
+        separator = "\n"
+
+        # if only one primary key, specify it along with the column
+        first_pk = False
+        for create_column in create.columns:
+            column = create_column.element
+            try:
+                processed = self.process(
+                    create_column, first_pk=column.primary_key and not first_pk
+                )
+                if processed is not None:
+                    text += separator
+                    separator = ", \n"
+                    text += "\t" + processed
+                if column.primary_key:
+                    first_pk = True
+            except sqlalchemy.exc.CompileError as ce:
+                raise sqlalchemy.exc.CompileError(
+                    "(in table '%s', column '%s'): %s"
+                    % (table.description, column.name, ce.args[0])
+                ) from ce
+
+        # Add table constraints
+        const = self.create_table_constraints(
+            table,
+            _include_foreign_key_constraints=create.include_foreign_key_constraints,  # noqa
+        )
+        if const:
+            text += separator + "\t" + const
+
+        # Add indexes inline
+        if hasattr(table, "indexes") and table.indexes:
+            for index in table.indexes:
+                try:
+                    # Create a CreateIndexInline object and process it using self.process
+                    create_index_inline = CreateIndexInline(index)
+                    index_def = self.process(create_index_inline)
+                    if index_def:
+                        text += separator + "\t" + index_def
+                        if separator == "\n":
+                            separator = ", \n"
+                except Exception:
+                    # If index compilation fails, skip it and let it be created separately
+                    pass
+
+        text += "\n)%s\n\n" % self.post_create_table(table)
+        return text
+
+    def visit_create_column(self, create, first_pk=False, **kw):
+        """Override visit_create_column to support inline column comment."""
+        column = create.element
+
+        if column.system:
+            return None
+
+        text = self.get_column_specification(column, first_pk=first_pk)
+        const = " ".join(self.process(constraint) for constraint in column.constraints)
+        if const:
+            text += " " + const
+
+        if column.comment is not None:
+            comment = self.sql_compiler.render_literal_value(
+                column.comment, sqltypes.String()
+            )
+            text += f" COMMENT {comment}"
+
+        return text
+
+    def _visit_create_index(self, create, inline=False, **kw):
+        """Internal method to handle both inline and standalone CREATE INDEX."""
+        # Copy from sqlalchemy.dialects.mysql.base.MySQLCompiler::visit_create_index
+        index = create.element
+        self._verify_index_table(index)
+        preparer = self.preparer
+        table = preparer.format_table(index.table)
+
+        columns = [
+            self.sql_compiler.process(
+                (
+                    elements.Grouping(expr)
+                    if (
+                        isinstance(expr, elements.BinaryExpression)
+                        or (
+                            isinstance(expr, elements.UnaryExpression)
+                            and expr.modifier
+                            not in (operators.desc_op, operators.asc_op)
+                        )
+                        or isinstance(expr, functions.FunctionElement)
+                    )
+                    else expr
+                ),
+                include_table=False,
+                literal_binds=True,
+            )
+            for expr in index.expressions
+        ]
+
+        name = self._prepared_index_name(index)
+
+        # Generate different text based on inline parameter
+        if inline:
+            # For inline index in CREATE TABLE, don't include CREATE, IF NOT EXISTS, or ON table
+            text = ""
+        else:
+            # For standalone CREATE INDEX
+            text = "CREATE "
+
+        if index.unique:
+            text += "UNIQUE "
+
+        index_prefix = index.kwargs.get("%s_prefix" % "mysql", None)
+        if index_prefix:
+            text += index_prefix + " "
+
+        text += "INDEX "
+
+        if not inline:
+            # Only add IF NOT EXISTS and table reference for standalone CREATE INDEX
+            if create.if_not_exists:
+                text += "IF NOT EXISTS "
+            text += "%s ON %s " % (name, table)
+        else:
+            # For inline index, just add the name
+            text += "%s " % name
+
+        length = index.dialect_options.get("mysql", {}).get("length")
+        if length is not None:
+            if isinstance(length, dict):
+                # length value can be a (column_name --> integer value)
+                # mapping specifying the prefix length for each column of the
+                # index
+                columns = ", ".join(
+                    (
+                        "%s(%d)" % (expr, length[col.name])
+                        if col.name in length
+                        else (
+                            "%s(%d)" % (expr, length[expr])
+                            if expr in length
+                            else "%s" % expr
+                        )
+                    )
+                    for col, expr in zip(index.expressions, columns)
+                )
+            else:
+                # or can be an integer value specifying the same
+                # prefix length for all columns of the index
+                columns = ", ".join("%s(%d)" % (col, length) for col in columns)
+        else:
+            columns = ", ".join(columns)
+
+        text += "(%s)" % columns
+
+        parser = index.dialect_options.get("mysql", {}).get("with_parser")
+        if parser is not None:
+            text += " WITH PARSER %s" % (parser,)
+
+        using = index.dialect_options.get("mysql", {}).get("using")
+        if using is not None:
+            text += " USING %s" % (using)
+
+        # Only add ADD_COLUMNAR_REPLICA_ON_DEMAND for standalone CREATE INDEX, not inline
+        if (
+            not inline
+            and hasattr(index, "ensure_columnar_replica")
+            and index.ensure_columnar_replica
+        ):
+            text += " ADD_COLUMNAR_REPLICA_ON_DEMAND"
+
+        return text
+
+    def visit_create_index(self, create, **kw):
+        """Generate standalone CREATE INDEX statement."""
+        return self._visit_create_index(create, inline=False, **kw)
+
+    def visit_create_index_inline(self, create, **kw):
+        """Generate inline index definition for CREATE TABLE statement."""
+        return self._visit_create_index(create, inline=True, **kw)
+
+    def visit_set_tiflash_replica(self, set_replica, **kw):
+        """Generate ALTER TABLE ... SET TIFLASH REPLICA statement."""
+        table = set_replica.table
+        replica_count = set_replica.replica_count
+
+        preparer = self.preparer
+        table_name = preparer.format_table(table)
+
+        return f"ALTER TABLE {table_name} SET TIFLASH REPLICA {replica_count}"
+
+
+class TiDBDialect(MySQLDialect_pymysql):
+    """Custom TiDB dialect with enhanced CREATE TABLE support."""
+
+    name = "tidb"
+    supports_comments = True
+    inline_comments = True  # Enable inline comments
+    supports_statement_cache = True  # Enable SQLAlchemy statement caching
+
+    # Use our custom compilers
+    statement_compiler = TiDBSQLCompiler
+    ddl_compiler = TiDBDDLCompiler
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # TiDB specific configurations
+        self.supports_comments = True
+        self.inline_comments = True

--- a/pytidb/orm/sql/ddl.py
+++ b/pytidb/orm/sql/ddl.py
@@ -1,115 +1,47 @@
-from sqlalchemy.sql.ddl import SchemaGenerator, CreateIndex
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql import elements, operators, functions
-
-
-@compiles(CreateIndex, "mysql")
-def compile_create_index(create, compiler, **kw):
-    # Copy from sqlalchemy.dialects.mysql.base.MySQLCompiler::visit_create_index
-    index = create.element
-    compiler._verify_index_table(index)
-    preparer = compiler.preparer
-    table = preparer.format_table(index.table)
-
-    columns = [
-        compiler.sql_compiler.process(
-            (
-                elements.Grouping(expr)
-                if (
-                    isinstance(expr, elements.BinaryExpression)
-                    or (
-                        isinstance(expr, elements.UnaryExpression)
-                        and expr.modifier not in (operators.desc_op, operators.asc_op)
-                    )
-                    or isinstance(expr, functions.FunctionElement)
-                )
-                else expr
-            ),
-            include_table=False,
-            literal_binds=True,
-        )
-        for expr in index.expressions
-    ]
-
-    name = compiler._prepared_index_name(index)
-
-    text = "CREATE "
-    if index.unique:
-        text += "UNIQUE "
-
-    index_prefix = index.kwargs.get("%s_prefix" % compiler.dialect.name, None)
-    if index_prefix:
-        text += index_prefix + " "
-
-    text += "INDEX "
-    if create.if_not_exists:
-        text += "IF NOT EXISTS "
-    text += "%s ON %s " % (name, table)
-
-    length = index.dialect_options[compiler.dialect.name]["length"]
-    if length is not None:
-        if isinstance(length, dict):
-            # length value can be a (column_name --> integer value)
-            # mapping specifying the prefix length for each column of the
-            # index
-            columns = ", ".join(
-                (
-                    "%s(%d)" % (expr, length[col.name])
-                    if col.name in length
-                    else (
-                        "%s(%d)" % (expr, length[expr])
-                        if expr in length
-                        else "%s" % expr
-                    )
-                )
-                for col, expr in zip(index.expressions, columns)
-            )
-        else:
-            # or can be an integer value specifying the same
-            # prefix length for all columns of the index
-            columns = ", ".join("%s(%d)" % (col, length) for col in columns)
-    else:
-        columns = ", ".join(columns)
-
-    text += "(%s)" % columns
-
-    parser = index.dialect_options[compiler.dialect.name]["with_parser"]
-    if parser is not None:
-        text += " WITH PARSER %s" % (parser,)
-
-    using = index.dialect_options[compiler.dialect.name]["using"]
-    if using is not None:
-        text += " USING %s" % (using)
-
-    if hasattr(index, "ensure_columnar_replica") and index.ensure_columnar_replica:
-        text += " ADD_COLUMNAR_REPLICA_ON_DEMAND"
-
-    return text
-
-
-class CreateVectorIndex(CreateIndex):
-    def __init__(self, element, if_not_exists=False):
-        super().__init__(element, if_not_exists=if_not_exists)
+from sqlalchemy.sql.ddl import (
+    SchemaGenerator,
+    CreateTable,
+)
 
 
 class TiDBSchemaGenerator(SchemaGenerator):
-    def visit_vector_index(self, index, create_ok=False):
-        if not create_ok and not self._can_create_index(index):
+    def visit_table(
+        self,
+        table,
+        create_ok=False,
+        include_foreign_key_constraints=None,
+        _is_metadata_operation=False,
+    ):
+        if not create_ok and not self._can_create_table(table):
             return
-        with self.with_ddl_events(index):
-            CreateVectorIndex(index)._invoke_with(self.connection)
 
+        with self.with_ddl_events(
+            table,
+            checkfirst=self.checkfirst,
+            _is_metadata_operation=_is_metadata_operation,
+        ):
+            for column in table.columns:
+                if column.default is not None:
+                    self.traverse_single(column.default)
 
-@compiles(CreateVectorIndex)
-def compile_create_vector_index(element, compiler, **kw):
-    index = element.index
-    table_name = index.table.name
-    column_name = index.columns[0].name
-    distance_metric = index.distance_metric
-    algorithm = index.algorithm
-    distance_metric_str = f"({distance_metric.to_sql_func()}({column_name}))"
+            if not self.dialect.supports_alter:
+                # e.g., don't omit any foreign key constraints
+                include_foreign_key_constraints = None
 
-    sql = f"CREATE VECTOR INDEX {index.name} ON {table_name} ({distance_metric_str}) USING {algorithm}"
-    if index.ensure_columnar_replica:
-        sql += " ADD_COLUMNAR_REPLICA_ON_DEMAND"
-    return sql
+            CreateTable(
+                table,
+                include_foreign_key_constraints=(include_foreign_key_constraints),
+            )._invoke_with(self.connection)
+
+    def visit_set_tiflash_replica(self, set_replica, checkfirst=False):
+        """Visit a SetTiFlashReplica DDL element."""
+        if checkfirst:
+            # Could add logic to check current replica count here
+            pass
+
+        # Generate and execute the DDL statement
+        from sqlalchemy import text
+
+        compiler = self.dialect.ddl_compiler(self.dialect, None)
+        stmt_str = compiler.visit_set_tiflash_replica(set_replica)
+        self.connection.execute(text(stmt_str))

--- a/pytidb/orm/tiflash_repilica.py
+++ b/pytidb/orm/tiflash_repilica.py
@@ -1,0 +1,143 @@
+from typing import Optional, Any, TYPE_CHECKING, Union
+from sqlalchemy.sql.schema import SchemaItem
+from sqlalchemy.sql.base import DialectKWArgs
+from sqlalchemy import text
+from pytidb.orm.sql.ddl import TiDBSchemaGenerator
+
+if TYPE_CHECKING:
+    from sqlalchemy import Table, Engine, Connection
+
+_CreateDropBind = Union["Engine", "Connection"]
+
+
+class SetTiFlashReplica:
+    """DDL element for SET TIFLASH REPLICA operation."""
+
+    __visit_name__ = "set_tiflash_replica"
+
+    def __init__(self, table: "Table", replica_count: int):
+        self.table = table
+        self.replica_count = replica_count
+
+
+class TiFlashReplica(DialectKWArgs, SchemaItem):
+    """A table-level TiFlash replica configuration.
+
+    TiFlash is the columnar storage engine for TiDB. This class provides
+    DDL operations to manage TiFlash replicas for tables.
+
+    Examples::
+
+        # Create TiFlash replica
+        replica = TiFlashReplica(table, replica_count=2)
+        replica.create(engine)
+
+        # Drop TiFlash replica
+        replica.drop(engine)
+
+        # Check replication progress
+        progress = replica.get_replication_progress(engine)
+
+    """
+
+    __visit_name__ = "tiflash_replica"
+
+    def __init__(
+        self,
+        table: "Table",
+        replica_count: int = 1,
+        quote: Optional[bool] = None,
+        info: Optional[dict] = None,
+        **dialect_kw: Any,
+    ) -> None:
+        """Construct a TiFlash replica object.
+
+        :param table: The table to configure TiFlash replicas for
+        :param replica_count: Number of replicas to create (0 to remove all replicas)
+        :param quote: Whether to apply quoting to table name
+        :param info: Optional data dictionary
+        :param **dialect_kw: Additional dialect-specific keyword arguments
+        """
+        if replica_count < 0:
+            raise ValueError("replica_count must be non-negative")
+
+        self.table = table
+        self.replica_count = replica_count
+
+        if info is not None:
+            self.info = info
+
+        self._validate_dialect_kwargs(dialect_kw)
+
+    def create(self, bind: _CreateDropBind, checkfirst: bool = False) -> None:
+        """Issue an ``ALTER TABLE ... SET TIFLASH REPLICA`` statement.
+
+        :param bind: Connection or Engine for connectivity
+        :param checkfirst: If True, check if operation is needed before executing
+        """
+        set_replica = SetTiFlashReplica(self.table, self.replica_count)
+        bind._run_ddl_visitor(TiDBSchemaGenerator, set_replica, checkfirst=checkfirst)
+
+    def drop(self, bind: _CreateDropBind, checkfirst: bool = False) -> None:
+        """Remove TiFlash replicas by setting replica count to 0.
+
+        :param bind: Connection or Engine for connectivity
+        :param checkfirst: If True, check if operation is needed before executing
+        """
+        set_replica = SetTiFlashReplica(self.table, 0)
+        bind._run_ddl_visitor(TiDBSchemaGenerator, set_replica, checkfirst=checkfirst)
+
+    def get_replication_progress(self, bind: _CreateDropBind) -> dict:
+        """Check TiFlash replication progress for the table.
+
+        :param bind: Connection or Engine for connectivity
+        :return: Dictionary with replication status information
+        """
+        if hasattr(bind, "execute"):
+            connection = bind
+        else:
+            connection = bind.connect()
+
+        try:
+            schema_name = (
+                self.table.schema
+                or connection.execute(text("SELECT DATABASE()")).scalar()
+            )
+            table_name = self.table.name
+
+            query = text("""
+            SELECT TABLE_SCHEMA, TABLE_NAME, REPLICA_COUNT, LOCATION_LABELS, 
+                   AVAILABLE, PROGRESS
+            FROM information_schema.tiflash_replica 
+            WHERE TABLE_SCHEMA = :schema_name AND TABLE_NAME = :table_name
+            """)
+
+            result = connection.execute(
+                query, {"schema_name": schema_name, "table_name": table_name}
+            )
+            row = result.fetchone()
+
+            if row:
+                return {
+                    "table_schema": row[0],
+                    "table_name": row[1],
+                    "replica_count": row[2],
+                    "location_labels": row[3],
+                    "available": bool(row[4]),
+                    "progress": float(row[5]) if row[5] is not None else 0.0,
+                }
+            else:
+                return {
+                    "table_schema": schema_name,
+                    "table_name": table_name,
+                    "replica_count": 0,
+                    "location_labels": "",
+                    "available": False,
+                    "progress": 0.0,
+                }
+        finally:
+            if hasattr(bind, "connect"):
+                connection.close()
+
+    def __repr__(self) -> str:
+        return f"TiFlashReplica({self.table.name}, replica_count={self.replica_count})"

--- a/pytidb/utils.py
+++ b/pytidb/utils.py
@@ -32,14 +32,8 @@ class TiDBConnectionURL(AnyUrl):
 
     _constraints = UrlConstraints(
         allowed_schemes=[
-            "mysql",
-            "mysql+mysqlconnector",
-            "mysql+aiomysql",
-            "mysql+asyncmy",
-            "mysql+mysqldb",
-            "mysql+pymysql",
-            "mysql+cymysql",
-            "mysql+pyodbc",
+            "tidb",
+            "tidb+pymysql",
         ],
         default_port=4000,
         host_required=True,
@@ -47,7 +41,7 @@ class TiDBConnectionURL(AnyUrl):
 
 
 def build_tidb_connection_url(
-    schema: str = "mysql+pymysql",
+    schema: str = "tidb+pymysql",
     host: str = "localhost",
     port: int = 4000,
     username: str = "root",
@@ -59,7 +53,7 @@ def build_tidb_connection_url(
     Build a TiDB Connection URL string for database connection.
 
     Args:
-        schema (str, optional): The connection protocol. Defaults to "mysql+pymysql".
+        schema (str, optional): The connection protocol. Defaults to "tidb+pymysql".
         host (str, optional): The host address of TiDB server. Defaults to "localhost".
         port (int, optional): The port number of TiDB server. Defaults to 4000.
         username (str, optional): The username for authentication. Defaults to "root".

--- a/tests/test_index_fulltext.py
+++ b/tests/test_index_fulltext.py
@@ -14,6 +14,9 @@ class TestCreateFullTextIndex:
     def setup_and_teardown(self, shared_client: TiDBClient):
         """Setup and teardown for each test method."""
         self.client = shared_client
+        # Skip tests if not connected to TiDB Serverless
+        if not self.client.is_serverless:
+            pytest.skip("Currently, Only TiDB Serverless supports full text indexes")
         yield
         self.client = None
 

--- a/tests/test_index_vector.py
+++ b/tests/test_index_vector.py
@@ -62,4 +62,5 @@ class TestCreateVectorIndex:
         )
         with pytest.warns(Warning):
             tbl.create_vector_index("text_vec")
+
         assert tbl.has_vector_index("text_vec")

--- a/tests/test_search_fulltext.py
+++ b/tests/test_search_fulltext.py
@@ -9,6 +9,10 @@ from pytidb.schema import TableModel, Field, FullTextField
 
 @pytest.fixture(scope="module")
 def text_table(shared_client: TiDBClient):
+    # Skip fulltext search tests if not connected to TiDB Serverless
+    if not shared_client.is_serverless:
+        pytest.skip("Currently, Only TiDB Serverless supports full text indexes")
+
     class ChunkWithFullTextField(TableModel):
         __tablename__ = "test_fulltext_search"
         id: int = Field(primary_key=True)
@@ -105,6 +109,10 @@ def test_rerank(text_table: Table, reranker: BaseReranker):
 
 
 def test_with_multiple_text_fields(shared_client: TiDBClient):
+    # Skip test if not connected to TiDB Serverless
+    if not shared_client.is_serverless:
+        pytest.skip("Currently, Only TiDB Serverless supports full text indexes")
+
     class Article(TableModel):
         __tablename__ = "test_fts_with_multi_text_fields"
         id: int = Field(primary_key=True)

--- a/tests/test_search_hybrid.py
+++ b/tests/test_search_hybrid.py
@@ -11,6 +11,10 @@ from pytidb.datatype import TEXT
 
 @pytest.fixture(scope="module")
 def hybrid_table(shared_client: TiDBClient):
+    # Skip hybrid search tests if not connected to TiDB Serverless
+    if not shared_client.is_serverless:
+        pytest.skip("Currently, Only TiDB Serverless supports full text indexes")
+
     embed_fn = EmbeddingFunction("openai/text-embedding-3-small", timeout=20)
 
     class Item(TableModel, table=True):


### PR DESCRIPTION
## Summary

This PR introduces several TiDB-specific enhancements for SQLAlchemy:

1. **New TiDB SQLAlchemy Dialect**  
   - Added `tidb` dialect support.  
   - You can now use either:
     ```python
     database_url = "tidb://user:password@host:port/dbname"
     # or
     database_url = "tidb+pymysql://user:password@host:port/dbname"
     ```
     to specify TiDB as the target database.

2. **TiFlash Replica DDL Support**  
   - Added a dedicated DDL object for TiFlash replicas.  
   - Implemented `CREATE`, `DROP`, and `GET_PROCESS` compilation for TiFlash Replica management.

3. **Custom `CREATE TABLE` Compilation for Inline Index Creation**  
   - **Background**:  
     By default, SQLAlchemy follows standard SQL syntax and creates indexes *after* creating the table:  
     1. Executes `CREATE TABLE` to create the table.  
     2. Executes separate `CREATE INDEX` statements for indexes defined in the `Table` object.  
     
     This works fine for regular indexes but **causes issues with Vector Index** in TiDB:
       - `CREATE INDEX` on a Vector Index requires ensuring a TiFlash replica exists.
       - **TiDB Serverless** can auto-create replicas via `ADD_COLUMNAR_REPLICA_ON_DEMAND`.
       - **TiDB (OP version)** does **not** support `ADD_COLUMNAR_REPLICA_ON_DEMAND` syntax and requires manual replica creation before index creation.

     If we create indexes **inline** in the `CREATE TABLE` statement, this problem disappears.

   - **Change**:  
     Overrode the `CREATE TABLE` compilation logic to allow index creation directly inside the table creation statement, ensuring compatibility with Vector Index in TiDB.

---

## Why This Matters

- **Simplifies TiDB connection setup** via a dedicated dialect.
- **Enables proper TiFlash replica management** through SQLAlchemy DDL.
- **Fixes Vector Index creation workflow** to work seamlessly in both TiDB Serverless and TiDB OP versions.
