### PR TITLE
docs: use tidb_client.db_engine in README example (fixes #193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ class User(TableModel):
     id: int = Field(primary_key=True)
     name: str = Field(max_length=20)
 
-with Session(engine) as session:
+# Use the db_engine from TiDBClient when creating a Session
+with Session(tidb_client.db_engine) as session:
     query = (
         select(Chunk).join(User, Chunk.user_id == User.id).where(User.name == "Alice")
     )


### PR DESCRIPTION
Fixes #193

The README previously used an undefined `engine` variable in the 
"Join Structured and Unstructured Data" example. 

This change updates the code example to use `tidb_client.db_engine`, 
making the example explicit and reducing confusion for new users.

Example after fix:

```python
# Use the db_engine from TiDBClient when creating a Session
with Session(tidb_client.db_engine) as session:
    query = (
        select(Chunk)
        .join(User, Chunk.user_id == User.id)
        .where(User.name == "Alice")
    )
    chunks = session.exec(query).all()
