### PR TITLE
Resolve github issue using context

### DIFF
--- a/examples/rag/main.py
+++ b/examples/rag/main.py
@@ -1,7 +1,6 @@
 import os
 import dotenv
 
-import litellm
 from litellm import completion
 import streamlit as st
 
@@ -10,7 +9,6 @@ from pytidb.schema import TableModel, Field
 from pytidb.embeddings import EmbeddingFunction
 
 dotenv.load_dotenv()
-litellm.drop_params = True
 
 
 # Define the embedding and LLM models


### PR DESCRIPTION
Remove explicit `litellm.drop_params` override and unused import to rely on LiteLLM's default parameter handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-24a16419-8a86-497b-a25a-bbfd674a957e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24a16419-8a86-497b-a25a-bbfd674a957e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

