### PR TITLE
feat: add query timeout support to TiDB MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,4 +257,4 @@ with tidb_client.session() as session:
 >
 > [![Install TiDB MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=TiDB&config=eyJjb21tYW5kIjoidXZ4IC0tZnJvbSBweXRpZGJbbWNwXSB0aWRiLW1jcC1zZXJ2ZXIiLCJlbnYiOnsiVElEQl9IT1NUIjoibG9jYWxob3N0IiwiVElEQl9QT1JUIjoiNDAwMCIsIlRJREJfVVNFUk5BTUUiOiJyb290IiwiVElEQl9QQVNTV09SRCI6IiIsIlRJREJfREFUQUJBU0UiOiJ0ZXN0In19)
 >
-> To limit long-running SQL statements in MCP, set `TIDB_MCP_QUERY_TIMEOUT` to the maximum execution time in seconds.
+> To limit long-running MCP queries, set `TIDB_MCP_QUERY_TIMEOUT` to the maximum execution time in seconds.

--- a/README.md
+++ b/README.md
@@ -256,3 +256,5 @@ with tidb_client.session() as session:
 > Click the button below to install **TiDB MCP Server** in Cursor. Then, confirm by clicking **Install** when prompted.
 >
 > [![Install TiDB MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=TiDB&config=eyJjb21tYW5kIjoidXZ4IC0tZnJvbSBweXRpZGJbbWNwXSB0aWRiLW1jcC1zZXJ2ZXIiLCJlbnYiOnsiVElEQl9IT1NUIjoibG9jYWxob3N0IiwiVElEQl9QT1JUIjoiNDAwMCIsIlRJREJfVVNFUk5BTUUiOiJyb290IiwiVElEQl9QQVNTV09SRCI6IiIsIlRJREJfREFUQUJBU0UiOiJ0ZXN0In19)
+>
+> To limit long-running SQL statements in MCP, set `TIDB_MCP_QUERY_TIMEOUT` to the maximum execution time in seconds.

--- a/pytidb/ext/mcp/__init__.py
+++ b/pytidb/ext/mcp/__init__.py
@@ -35,7 +35,7 @@ from pytidb.ext.mcp.server import create_mcp_server, log
     type=click.IntRange(min=1),
     envvar="TIDB_MCP_QUERY_TIMEOUT",
     default=None,
-    help="Maximum execution time for each SQL statement in seconds",
+    help="Maximum execution time for TiDB queries in seconds",
 )
 def main(
     transport: Literal["stdio", "sse", "streamable-http"] = "stdio",

--- a/pytidb/ext/mcp/__init__.py
+++ b/pytidb/ext/mcp/__init__.py
@@ -30,10 +30,18 @@ from pytidb.ext.mcp.server import create_mcp_server, log
     show_default=True,
     help="Port to bind for network transports",
 )
+@click.option(
+    "--query-timeout",
+    type=click.IntRange(min=1),
+    envvar="TIDB_MCP_QUERY_TIMEOUT",
+    default=None,
+    help="Maximum execution time for each SQL statement in seconds",
+)
 def main(
     transport: Literal["stdio", "sse", "streamable-http"] = "stdio",
     host: str = "127.0.0.1",
     port: int = 8000,
+    query_timeout: int | None = None,
 ):
     logging.basicConfig(
         level=logging.INFO,
@@ -47,5 +55,6 @@ def main(
         host=host,
         port=port,
         stateless_http=stateless,
+        query_timeout=query_timeout,
     )
     mcp.run(transport=transport)

--- a/pytidb/ext/mcp/server.py
+++ b/pytidb/ext/mcp/server.py
@@ -38,9 +38,11 @@ class TiDBConnector:
         username: Optional[str] = None,
         password: Optional[str] = None,
         database: Optional[str] = None,
+        query_timeout: Optional[int] = None,
     ):
-        self.tidb_client = TiDBClient.connect(
-            url=database_url,
+        self.query_timeout = query_timeout
+        self.tidb_client = self._connect_client(
+            database_url=database_url,
             host=host,
             port=port,
             username=username,
@@ -53,13 +55,41 @@ class TiDBConnector:
             self.port = uri.port
             self.username = uri.username
             self.password = uri.password
-            self.database = uri.path.lstrip("/")
+            self.database = (uri.path or "").lstrip("/") or None
         else:
             self.host = host
             self.port = port
             self.username = username
             self.password = password
             self.database = database
+
+    def _connect_client(
+        self,
+        *,
+        database_url: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        database: Optional[str] = None,
+    ) -> TiDBClient:
+        connect_kwargs = {}
+        if self.query_timeout is not None:
+            connect_kwargs["connect_args"] = {
+                "init_command": (
+                    f"SET SESSION max_execution_time = {self.query_timeout * 1000}"
+                )
+            }
+
+        return TiDBClient.connect(
+            url=database_url,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            database=database,
+            **connect_kwargs,
+        )
 
     def show_databases(self) -> list[dict]:
         return self.tidb_client.query("SHOW DATABASES").to_list()
@@ -70,7 +100,7 @@ class TiDBConnector:
         username: Optional[str] = None,
         password: Optional[str] = None,
     ) -> None:
-        self.tidb_client = TiDBClient.connect(
+        self.tidb_client = self._connect_client(
             host=self.host,
             port=self.port,
             username=username or self.username,
@@ -98,7 +128,7 @@ class TiDBConnector:
 
     @property
     def is_tidb_serverless(self) -> bool:
-        return TIDB_SERVERLESS_HOST_PATTERN.match(self.host)
+        return bool(self.host and TIDB_SERVERLESS_HOST_PATTERN.match(self.host))
 
     def current_username(self) -> str:
         current_user = self.tidb_client.query("SELECT CURRENT_USER()").scalar() or ""
@@ -149,27 +179,34 @@ class AppContext:
     tidb: TiDBConnector
 
 
-@asynccontextmanager
-async def app_lifespan(app: FastMCP) -> AsyncIterator[AppContext]:
-    tidb = None
-    try:
-        log.info("Starting TiDB Connector...")
-        tidb = TiDBConnector(
-            database_url=os.getenv("TIDB_DATABASE_URL", None),
-            host=os.getenv("TIDB_HOST", "127.0.0.1"),
-            port=int(os.getenv("TIDB_PORT", "4000")),
-            username=os.getenv("TIDB_USERNAME", "root"),
-            password=os.getenv("TIDB_PASSWORD", ""),
-            database=os.getenv("TIDB_DATABASE", "test"),
-        )
-        log.info(f"Connected to TiDB: {tidb.host}:{tidb.port}/{tidb.database}")
-        yield AppContext(tidb=tidb)
-    except Exception as e:
-        log.error(f"Failed to connect to TiDB: {e}")
-        raise e
-    finally:
-        if tidb:
-            tidb.disconnect()
+def create_app_lifespan(query_timeout: Optional[int] = None):
+    @asynccontextmanager
+    async def app_lifespan(app: FastMCP) -> AsyncIterator[AppContext]:
+        tidb = None
+        try:
+            log.info("Starting TiDB Connector...")
+            tidb = TiDBConnector(
+                database_url=os.getenv("TIDB_DATABASE_URL", None),
+                host=os.getenv("TIDB_HOST", "127.0.0.1"),
+                port=int(os.getenv("TIDB_PORT", "4000")),
+                username=os.getenv("TIDB_USERNAME", "root"),
+                password=os.getenv("TIDB_PASSWORD", ""),
+                database=os.getenv("TIDB_DATABASE", "test"),
+                query_timeout=query_timeout,
+            )
+            log.info(f"Connected to TiDB: {tidb.host}:{tidb.port}/{tidb.database}")
+            yield AppContext(tidb=tidb)
+        except Exception as e:
+            log.error(f"Failed to connect to TiDB: {e}")
+            raise e
+        finally:
+            if tidb:
+                tidb.disconnect()
+
+    return app_lifespan
+
+
+app_lifespan = create_app_lifespan()
 
 
 # Tool functions (defined outside for clarity)
@@ -250,6 +287,7 @@ def create_mcp_server(
     host: str = "127.0.0.1",
     port: int = 8000,
     stateless_http: bool = True,
+    query_timeout: Optional[int] = None,
 ) -> FastMCP:
     """Create and configure the TiDB MCP server."""
     mcp = FastMCP(
@@ -284,7 +322,7 @@ via the `<db_name>.<table_name>` syntax.
     ```
 
     """,
-        lifespan=app_lifespan,
+        lifespan=create_app_lifespan(query_timeout),
         host=host,
         port=port,
         stateless_http=stateless_http,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,7 +8,7 @@ import pytidb.ext.mcp as mcp_cli
 import pytidb.ext.mcp.server as mcp_server
 
 
-def test_mcp_cli_forwards_query_timeout(monkeypatch):
+def test_mcp_cli_option_forwards_query_timeout(monkeypatch):
     captured = {}
 
     class DummyServer:
@@ -21,14 +21,10 @@ def test_mcp_cli_forwards_query_timeout(monkeypatch):
 
     monkeypatch.setattr(mcp_cli, "create_mcp_server", fake_create_mcp_server)
 
-    callback = mcp_cli.main.callback
-    assert callback is not None
-
-    callback(
-        transport="streamable-http",
-        host="127.0.0.1",
-        port=8000,
-        query_timeout=12,
+    mcp_cli.main.main(
+        args=["--transport", "streamable-http", "--query-timeout", "12"],
+        prog_name="tidb-mcp-server",
+        standalone_mode=False,
     )
 
     assert captured == {
@@ -37,6 +33,35 @@ def test_mcp_cli_forwards_query_timeout(monkeypatch):
         "stateless_http": True,
         "query_timeout": 12,
         "transport": "streamable-http",
+    }
+
+
+def test_mcp_cli_env_var_forwards_query_timeout(monkeypatch):
+    captured = {}
+
+    class DummyServer:
+        def run(self, transport):
+            captured["transport"] = transport
+
+    def fake_create_mcp_server(**kwargs):
+        captured.update(kwargs)
+        return DummyServer()
+
+    monkeypatch.setattr(mcp_cli, "create_mcp_server", fake_create_mcp_server)
+    monkeypatch.setenv("TIDB_MCP_QUERY_TIMEOUT", "15")
+
+    mcp_cli.main.main(
+        args=[],
+        prog_name="tidb-mcp-server",
+        standalone_mode=False,
+    )
+
+    assert captured == {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "stateless_http": False,
+        "query_timeout": 15,
+        "transport": "stdio",
     }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,137 @@
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("mcp.server.fastmcp")
+
+import pytidb.ext.mcp as mcp_cli
+import pytidb.ext.mcp.server as mcp_server
+
+
+def test_mcp_cli_forwards_query_timeout(monkeypatch):
+    captured = {}
+
+    class DummyServer:
+        def run(self, transport):
+            captured["transport"] = transport
+
+    def fake_create_mcp_server(**kwargs):
+        captured.update(kwargs)
+        return DummyServer()
+
+    monkeypatch.setattr(mcp_cli, "create_mcp_server", fake_create_mcp_server)
+
+    callback = mcp_cli.main.callback
+    assert callback is not None
+
+    callback(
+        transport="streamable-http",
+        host="127.0.0.1",
+        port=8000,
+        query_timeout=12,
+    )
+
+    assert captured == {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "stateless_http": True,
+        "query_timeout": 12,
+        "transport": "streamable-http",
+    }
+
+
+def test_tidb_connector_sets_query_timeout_init_command(monkeypatch):
+    calls = []
+
+    def fake_connect(**kwargs):
+        calls.append(kwargs)
+        return Mock()
+
+    monkeypatch.setattr(mcp_server.TiDBClient, "connect", staticmethod(fake_connect))
+
+    mcp_server.TiDBConnector(
+        host="127.0.0.1",
+        port=4000,
+        username="root",
+        password="",
+        database="test",
+        query_timeout=7,
+    )
+
+    assert calls == [
+        {
+            "url": None,
+            "host": "127.0.0.1",
+            "port": 4000,
+            "username": "root",
+            "password": "",
+            "database": "test",
+            "connect_args": {
+                "init_command": "SET SESSION max_execution_time = 7000"
+            },
+        }
+    ]
+
+
+def test_tidb_connector_preserves_query_timeout_when_switching_databases(monkeypatch):
+    calls = []
+
+    def fake_connect(**kwargs):
+        client = Mock()
+        client.disconnect = Mock()
+        calls.append(kwargs)
+        return client
+
+    monkeypatch.setattr(mcp_server.TiDBClient, "connect", staticmethod(fake_connect))
+
+    connector = mcp_server.TiDBConnector(
+        host="127.0.0.1",
+        port=4000,
+        username="root",
+        password="",
+        database="test",
+        query_timeout=9,
+    )
+
+    connector.switch_database("analytics")
+
+    assert calls[1] == {
+        "url": None,
+        "host": "127.0.0.1",
+        "port": 4000,
+        "username": "root",
+        "password": "",
+        "database": "analytics",
+        "connect_args": {
+            "init_command": "SET SESSION max_execution_time = 9000"
+        },
+    }
+
+
+def test_create_app_lifespan_passes_query_timeout(monkeypatch):
+    captured = {}
+
+    class FakeConnector:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.host = kwargs["host"]
+            self.port = kwargs["port"]
+            self.database = kwargs["database"]
+
+        def disconnect(self):
+            captured["disconnected"] = True
+
+    monkeypatch.setattr(mcp_server, "TiDBConnector", FakeConnector)
+
+    lifespan = mcp_server.create_app_lifespan(15)
+
+    async def run_lifespan():
+        async with lifespan(Mock()):
+            pass
+
+    import asyncio
+
+    asyncio.run(run_lifespan())
+
+    assert captured["query_timeout"] == 15
+    assert captured["disconnected"] is True


### PR DESCRIPTION
## Summary
- add a `--query-timeout` / `TIDB_MCP_QUERY_TIMEOUT` option to the TiDB MCP server CLI
- apply the configured timeout to TiDB sessions via `max_execution_time` so long-running MCP queries fail sooner and reconnects keep the same setting
- add MCP-focused unit coverage for CLI flag wiring, env-var wiring, and database switching, and document the new setting in the README

## Testing
- `python -m pytest --noconftest tests/test_mcp_server.py -q`
- `python -m pytidb.ext.mcp --help`
- `python -m compileall pytidb/ext/mcp tests/test_mcp_server.py`

Closes #261